### PR TITLE
Add Russian localization

### DIFF
--- a/lambdacms-core/LambdaCms/Core/Foundation.hs
+++ b/lambdacms-core/LambdaCms/Core/Foundation.hs
@@ -28,7 +28,8 @@ import           Data.Time.Format.Human
 import           Data.Traversable           (forM)
 import           Database.Persist.Sql       (SqlBackend)
 import           LambdaCms.Core.Message     (CoreMessage, defaultMessage,
-                                             dutchMessage, englishMessage)
+                                             dutchMessage, englishMessage,
+                                             russianMessage)
 import qualified LambdaCms.Core.Message     as Msg
 import           LambdaCms.Core.Models
 import           LambdaCms.Core.Settings
@@ -217,6 +218,7 @@ class ( YesodAuth master
         case (lang `elem` (renderLanguages m), lang) of
             (True, "en") -> englishMessage
             (True, "nl") -> dutchMessage
+            (True, "ru") -> russianMessage
             _ -> renderCoreMessage m langs
     renderCoreMessage _ _ = defaultMessage
 

--- a/lambdacms-core/LambdaCms/Core/Message.hs
+++ b/lambdacms-core/LambdaCms/Core/Message.hs
@@ -7,9 +7,12 @@ module LambdaCms.Core.Message
          -- * All languages
        , englishMessage
        , dutchMessage
+       , russianMessage
        ) where
 
-import           Data.Text   (Text)
+import           Data.Monoid ((<>))
+import           Data.Text   (Text, unpack)
+import           Text.Read   (readMaybe)
 
 
 data CoreMessage =
@@ -269,3 +272,128 @@ dutchMessage (WelcomeTitle name)             = "Welkom, " `mappend` name `mappen
 dutchMessage (WelcomeIntro site)             = "Je bekijkt de beheeromgeving van " `mappend` site `mappend` ", die gebouwd is met behulp van LambdaCms."
 dutchMessage WelcomeMenu                     = "Met het menu aan de linker kant kan je navigeren door de beheeromgeving om deze website te beheren."
 dutchMessage WelcomeInfo                     = "Voor meer informatie over LambdaCms kan je terecht op <a href='http://www.lambdacms.org'>www.lambdacms.org</a>."
+
+russianMessage :: CoreMessage -> Text
+russianMessage Dashboard                       = "Панель инструментов"
+russianMessage LambdaCms                       = "LambdaCms"
+russianMessage NotLoggedIn                     = "Вход не выполнен"
+russianMessage You                             = "Вы"
+russianMessage Logout                          = "Выход"
+russianMessage AccountSettings                 = "Настройки учётной записи"
+russianMessage UserIndex                       = "Просмотр пользователей"
+russianMessage EmailAddress                    = "Адрес эл.почты"
+russianMessage NewUser                         = "Новый пользователь"
+russianMessage (EditUser name)                 = name
+russianMessage ChangeAccountSettings           = "Изменить настройки учётной записи"
+russianMessage ChangeRoles                     = "Выберите роли"
+russianMessage ChangePassword                  = "Изменить пароль"
+russianMessage ResetPassword                   = "Сбросить пароль"
+russianMessage RequestResetToken_Text          = "Сбросить пароль данного пользователя и отправить ему на эл.почту новое проверочное письмо"
+russianMessage RequestResetToken_Button        = "Запросить сброс пароля"
+russianMessage PasswordResetTokenSend          = "Ссылка для сброса пароля выслана"
+russianMessage PasswordTooShort                = "Слишком короткий пароль"
+russianMessage PasswordMismatch                = "Пароли не совпадают"
+russianMessage Username                        = "Имя пользователя"
+russianMessage Password                        = "Пароль"
+russianMessage Roles                           = "Роли"
+russianMessage Confirm                         = "Подтвердить"
+russianMessage Create                          = "Создать"
+russianMessage Save                            = "Сохранить"
+russianMessage Submit                          = "Отправить"
+russianMessage Change                          = "Изменить"
+russianMessage Back                            = "Назад"
+russianMessage BackHome                        = "на главную страницу"
+russianMessage Remove                          = "Удалить"
+russianMessage Deactivate                      = "Деактивировать"
+russianMessage Activate                        = "Активировать"
+russianMessage UserDeactivated                 = "Пользователь деактивирован"
+russianMessage UserActivated                   = "Пользователь активирован"
+russianMessage UserStillPending                = "Невозможно выполнить действие, пользователь ещё не прошёл проверку"
+russianMessage CreatedOn                       = "Создан"
+russianMessage LastLogin                       = "Последний вход"
+russianMessage AccountStatus                   = "Настройки учётной записи"
+russianMessage AccountPending                  = "Ожидает проверки"
+russianMessage AccountActive                   = "Активный"
+russianMessage AccountInactive                 = "Неактивный"
+russianMessage AccountAlreadyActivated         = "Эта учётная запись уже активирована"
+russianMessage ActivationSuccess               = "Учётная запись успешно активирована"
+russianMessage TokenMismatch                   = "Неверный ключ"
+russianMessage NoUsersFound                    = "Пользователей не найдено."
+russianMessage SuccessCreate                   = "Создание прошло успешно"
+russianMessage SuccessReplace                  = "Замена прошла успешно"
+russianMessage SuccessUpdate                   = "Обновление прошло успешно"
+russianMessage SuccessChgPwd                   = "Пароль успешно изменён"
+russianMessage SuccessDelete                   = "Удаление прошло успешно"
+russianMessage MenuDashboard                   = russianMessage Dashboard
+russianMessage MenuUsers                       = "Пользователи"
+russianMessage (DeletedUser name)              = "Пользователь " `mappend` name `mappend` " удалён"
+russianMessage TimeJustNow                     = "Только что"
+russianMessage (TimeSecondsAgo time)           = pluralCountRu time RuWordSecond `mappend` ruAgo
+russianMessage TimeOneMinuteAgo                = "минуту назад"
+russianMessage (TimeMinutesAgo time)           = pluralCountRu time RuWordMinute `mappend` ruAgo
+russianMessage TimeOneHourAgo                  = "час назад"
+russianMessage (TimeAboutHoursAgo time)        = "около " `mappend` pluralCountRu time RuWordHour `mappend` ruAgo
+russianMessage (TimeAt time)                   = "в " `mappend` time
+russianMessage (TimeDaysAgo time)              = pluralCountRu time RuWordDay `mappend` ruAgo
+russianMessage (TimeWeekAgo time)              = russianMessage (TimeWeeksAgo time)
+russianMessage (TimeWeeksAgo time)             = pluralCountRu time RuWordWeek `mappend` ruAgo
+russianMessage (TimeOnYear time)               = "в " `mappend` time
+russianMessage DayOfWeekFmt                    = "%A, %l:%M %p"
+russianMessage ActionLogIndex                  = "Действия"
+russianMessage NoActionLogsFound               = "Действий пока не было"
+russianMessage (LogCreatedUser name)           = "Создан новый пользователь \"" `mappend` name `mappend` "\""
+russianMessage (LogUpdatedUser name)           = "Обновлён пользователь \"" `mappend` name `mappend` "\" "
+russianMessage (LogDeletedUser name)           = "Удалён пользователь \"" `mappend` name `mappend` "\""
+russianMessage (LogChangedPasswordUser name)   = "Изменён пароль пользователя \"" `mappend` name `mappend` "\""
+russianMessage (LogRequestedPasswordUser name) = "Пользователю \"" `mappend` name `mappend` "\" выслан ключ для сброса пароля"
+russianMessage (LogDeactivatedUser name)       = "Деактивирован пользователь \"" `mappend` name `mappend` "\""
+russianMessage (LogActivatedUser name)         = "Активирован пользователь \"" `mappend` name `mappend` "\""
+russianMessage AllLogs                         = "Все события"
+russianMessage PersonalLogs                    = "Ваша деятельность"
+russianMessage InvalidOffset                   = "Неверное значение сдвига \"offset\""
+russianMessage InvalidLimit                    = "Неверное значение ограничения \"limit\""
+russianMessage LoadMore                        = "загрузить больше"
+russianMessage (WelcomeTitle name)             = "Добро пожаловать, " `mappend` name `mappend` "!"
+russianMessage (WelcomeIntro site)             = "Вы просматриваете интерфейс управления сайта " `mappend` site `mappend` ", основанный на LambdaCms."
+russianMessage WelcomeMenu                     = "С помощью меню слева вы можете перемещаться по интерфейсу и управлять сайтом."
+russianMessage WelcomeInfo                     = "Если вам нужно получить дополнительную информацию о LambdaCms, пожалуйста, посетите <a href='http://www.lambdacms.org'>www.lambdacms.org</a>."
+
+pluralCountRu :: Text -> RussianWord -> Text
+pluralCountRu tn w =
+    case mayRead of
+        Nothing -> pluralCountRu' 0 w -- most common case
+        Just  n -> pluralCountRu' n w
+ where
+   mayRead = readMaybe (unpack tn) :: Maybe Int
+   pluralCountRu' :: Int -> RussianWord -> Text
+   pluralCountRu' n w
+       | n >= 10 && n <= 20   = tn <> " " <> plural0Ru w
+       | rem == 1             = tn <> " " <> plural1Ru w
+       | rem >= 2 && rem <= 4 = tn <> " " <> plural234Ru w
+       | otherwise            = tn <> " " <> plural0Ru w -- 0, 5-9
+     where rem = n `mod` 10
+   plural1Ru RuWordSecond = "секунду"
+   plural1Ru RuWordMinute = "минуту"
+   plural1Ru RuWordHour = "час"
+   plural1Ru RuWordDay = "день"
+   plural1Ru RuWordWeek = "неделю"
+   plural234Ru RuWordSecond = "секунды"
+   plural234Ru RuWordMinute = "минуты"
+   plural234Ru RuWordHour = "часа"
+   plural234Ru RuWordDay = "дня"
+   plural234Ru RuWordWeek = "недели"
+   plural0Ru RuWordSecond = "секунд"
+   plural0Ru RuWordMinute = "минут"
+   plural0Ru RuWordHour = "часов"
+   plural0Ru RuWordDay = "дней"
+   plural0Ru RuWordWeek = "недель"
+
+ruAgo :: Text
+ruAgo = " назад"
+
+data RussianWord
+    = RuWordSecond
+    | RuWordMinute
+    | RuWordHour
+    | RuWordDay
+    | RuWordWeek

--- a/lambdacms-core/LambdaCms/I18n.hs
+++ b/lambdacms-core/LambdaCms/I18n.hs
@@ -6,10 +6,12 @@ import           Data.Text
 import           Data.Time.Format (defaultTimeLocale, TimeLocale)
 import           LambdaCms.I18n.Dutch
 import           LambdaCms.I18n.Italian
+import           LambdaCms.I18n.Russian
 
 
 -- | Helper function to get the right time locale.
 lambdaCmsTimeLocale :: [Text] -> TimeLocale
 lambdaCmsTimeLocale ("nl":_) = dutchTimeLocale
 lambdaCmsTimeLocale ("it":_) = italianTimeLocale
+lambdaCmsTimeLocale ("ru":_) = russianTimeLocale
 lambdaCmsTimeLocale _        = defaultTimeLocale

--- a/lambdacms-core/LambdaCms/I18n/Russian.hs
+++ b/lambdacms-core/LambdaCms/I18n/Russian.hs
@@ -1,0 +1,28 @@
+module LambdaCms.I18n.Russian where
+
+import           Data.Time.Format (TimeLocale(..))
+
+
+-- | Dutch time locale.
+russianTimeLocale :: TimeLocale
+russianTimeLocale =  TimeLocale
+    {
+        wDays  = [("Воскресенье", "Вс"),  ("Понедельник", "Пн"),
+                  ("Вторник",     "Вт"),  ("Среда",       "Ср"),
+                  ("Четверг",     "Чт"),  ("Пятница",     "Пт"),
+                  ("Суббота",     "Сб")],
+
+        months = [("Январь",   "Янв"), ("Февраль", "Фев"),
+                  ("Март",     "Мар"), ("Апрель",  "Апр"),
+                  ("Май",      "Май"), ("Июнь",    "Июн"),
+                  ("Июль",     "Июл"), ("Август",  "Авг"),
+                  ("Сентябрь", "Сен"), ("Октябрь", "Окт"),
+                  ("Ноябрь",   "Ноя"), ("Декабрь", "Дек")],
+
+        amPm = ("am", "pm"),
+        dateTimeFmt = "%a, %e %b %Y %H:%M:%S %Z",
+        dateFmt = "%d.%m.%y",
+        timeFmt = "%H:%M:%S",
+        time12Fmt = "%H:%M:%S",
+        knownTimeZones = []
+    }

--- a/lambdacms-core/lambdacms-core.cabal
+++ b/lambdacms-core/lambdacms-core.cabal
@@ -1,5 +1,5 @@
 name:               lambdacms-core
-version:            0.3.0.2
+version:            0.3.0.3
 license:            MIT
 license-file:       LICENSE
 author:             Cies Breijs, Mats Rietdijk, Rutger van Aalst

--- a/lambdacms-core/lambdacms-core.cabal
+++ b/lambdacms-core/lambdacms-core.cabal
@@ -54,8 +54,9 @@ library
                   , LambdaCms.I18n
                   , LambdaCms.I18n.Dutch
                   , LambdaCms.I18n.Italian
+                  , LambdaCms.I18n.Russian
 
-  build-depends:    base                               >= 4.3     && < 5
+  build-depends:    base                               >= 4.6     && < 5
                   , yesod
                   , yesod-core
                   , yesod-auth

--- a/lambdacms-media/LambdaCms/Media/Foundation.hs
+++ b/lambdacms-media/LambdaCms/Media/Foundation.hs
@@ -18,7 +18,8 @@ import           Yesod
 import           LambdaCms.Core
 
 import           LambdaCms.Media.Message (MediaMessage, defaultMessage,
-                                          dutchMessage, englishMessage)
+                                          dutchMessage, englishMessage,
+                                          russianMessage)
 import qualified LambdaCms.Media.Message as Msg
 import           LambdaCms.Media.Models
 
@@ -52,6 +53,7 @@ class LambdaCmsAdmin master => LambdaCmsMedia master where
         case (lang `elem` (renderLanguages m), lang) of
             (True, "en") -> englishMessage
             (True, "nl") -> dutchMessage
+            (True, "ru") -> russianMessage
             _ -> renderMediaMessage m langs
     renderMediaMessage _ _ = defaultMessage
 

--- a/lambdacms-media/LambdaCms/Media/Message.hs
+++ b/lambdacms-media/LambdaCms/Media/Message.hs
@@ -6,6 +6,7 @@ module LambdaCms.Media.Message
          -- * All languages
        , englishMessage
        , dutchMessage
+       , russianMessage
        ) where
 
 import           Data.Monoid as Import ((<>))
@@ -113,3 +114,36 @@ dutchMessage (DeleteSuccess labelM) = "Succesvol verwijderd: " <> labelM
 dutchMessage (DeleteFail labelM)    = "Verwijderen mislukt voor: " <> labelM
 dutchMessage RenameSuccess          = "Bestand succesvol hernoemd"
 dutchMessage RenameFail             = "Hernoemen van bestand mislukt"
+
+russianMessage :: MediaMessage -> Text
+russianMessage Back                   = "Назад"
+russianMessage Delete                 = "Удалить"
+russianMessage Save                   = "Сохранить"
+russianMessage Upload                 = "Загрузить"
+russianMessage Rename                 = "Переименовать"
+russianMessage AddMedia               = "Добавить медиа-файл"
+russianMessage NoMediaFound           = "Медиа-файлы не найдены."
+russianMessage CantDisplayFileType    = "Невозможно отобразить содержимое файла"
+russianMessage UnknownFileType        = "Неизвестный формат файла"
+russianMessage MediaIndex             = "Просмотр медиа-файлов"
+russianMessage NewMedia               = "Новый медиа-файл"
+russianMessage (EditMedia labelM)     = labelM
+russianMessage Information            = "Информация о файле"
+russianMessage Preview                = "Предпросмотр"
+russianMessage Location               = "Файл"
+russianMessage NewFilename            = "Новое имя файла"
+russianMessage ChangeMediaSettings    = "Изменить настройки медиа-файла"
+russianMessage ChangeFilename         = "Изменить имя файла"
+russianMessage Label                  = "Метка"
+russianMessage Description            = "Описание"
+russianMessage UploadedOn             = "Загружено"
+russianMessage Filename               = "Имя файла"
+russianMessage FileContentType        = "Тип содержимого"
+russianMessage FileLocation           = "Расположение файла"
+russianMessage MenuMedia              = "Медиа-файлы"
+russianMessage (SaveSuccess labelM)   = "Создание прошло успешно: " <>  labelM
+russianMessage (UpdateSuccess labelM) = "Обновление прошло успешно: " <> labelM
+russianMessage (DeleteSuccess labelM) = "Удаление прошло успешно: " <> labelM
+russianMessage (DeleteFail labelM)    = "Не получилось удалить: " <> labelM
+russianMessage RenameSuccess          = "Переименование файла прошло успешно"
+russianMessage RenameFail             = "Переименование файла не удалось"


### PR DESCRIPTION
Note, I've bumped version of `base` dependency to **4.6** because of `readMaybe` function, I hope this is not very important.

Here is some questions:
1. why English translation of `SuccessCreate` in core package is lowercased while replace and update does not? [[1](https://github.com/lambdacms/lambdacms/blob/11e7a34881b03e9ac1530a10c01ef7c89fedff92/lambdacms-core/LambdaCms/Core/Message.hs#L149)]
2. what means "user is pending"? (I didn't get familiar with CMS yet, so it's unclear what is the best translation should be). Does it mean "user is not activated/verified yet"?
