### PR TITLE
Select HumanTimeLocale depending on language

### DIFF
--- a/lambdacms-core/LambdaCms/Core/Foundation.hs
+++ b/lambdacms-core/LambdaCms/Core/Foundation.hs
@@ -20,10 +20,9 @@ import           Data.Monoid                ((<>))
 import           Data.Ord                   (comparing)
 import           Data.Set                   (Set)
 import qualified Data.Set                   as S (empty, intersection, null)
-import           Data.Text                  (Text, concat, intercalate, pack,
-                                             unpack)
+import           Data.Text                  (Text, concat, intercalate, unpack)
 import           Data.Text.Encoding         (decodeUtf8)
-import           Data.Time                  (getCurrentTime, utc)
+import           Data.Time                  (getCurrentTime)
 import           Data.Time.Format.Human
 import           Data.Traversable           (forM)
 import           Database.Persist.Sql       (SqlBackend)
@@ -361,24 +360,8 @@ lambdaCmsHumanTimeLocale = do
     langs <- languages
     y <- getYesod
     let rm = unpack . renderMessage y langs
-    return $ HumanTimeLocale
-        { justNow       = rm Msg.TimeJustNow
-        , secondsAgo    = (\_ x -> rm . Msg.TimeSecondsAgo $ pack x)
-        , oneMinuteAgo  = (\_   -> rm Msg.TimeOneMinuteAgo)
-        , minutesAgo    = (\_ x -> rm . Msg.TimeMinutesAgo $ pack x)
-        , oneHourAgo    = (\_   -> rm Msg.TimeOneHourAgo)
-        , aboutHoursAgo = (\_ x -> rm . Msg.TimeAboutHoursAgo $ pack x)
-        , at            = (\_ x -> rm $ Msg.TimeAt $ pack x)
-        , daysAgo       = (\_ x -> rm . Msg.TimeDaysAgo $ pack x)
-        , weekAgo       = (\_ x -> rm . Msg.TimeWeekAgo $ pack x)
-        , weeksAgo      = (\_ x -> rm . Msg.TimeWeeksAgo $ pack x)
-        , onYear        = rm . Msg.TimeOnYear . pack
-        , locale        = lambdaCmsTimeLocale langs
-        , dayOfWeekFmt  = rm Msg.DayOfWeekFmt
-        , thisYearFmt   = "%b %e"
-        , prevYearFmt   = "%b %e, %Y"
-        , timeZone      = utc
-        }
+        htl = lambdaCmsSelectHumanTimeLocale langs rm
+    return htl
 
 routeBestMatch :: RenderRoute master
                   => Maybe (Route master)

--- a/lambdacms-core/LambdaCms/I18n.hs
+++ b/lambdacms-core/LambdaCms/I18n.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
-
 module LambdaCms.I18n where
 
-import           Data.Text
-import           Data.Time.Format (defaultTimeLocale, TimeLocale)
+import           Data.Text              (Text)
+import           Data.Time.Format       (TimeLocale, defaultTimeLocale)
 import           Data.Time.Format.Human (HumanTimeLocale)
 import           LambdaCms.Core.Message (CoreMessage)
 import           LambdaCms.I18n.Default (defaultHumanTimeLocale)

--- a/lambdacms-core/LambdaCms/I18n.hs
+++ b/lambdacms-core/LambdaCms/I18n.hs
@@ -4,6 +4,9 @@ module LambdaCms.I18n where
 
 import           Data.Text
 import           Data.Time.Format (defaultTimeLocale, TimeLocale)
+import           Data.Time.Format.Human (HumanTimeLocale)
+import           LambdaCms.Core.Message (CoreMessage)
+import           LambdaCms.I18n.Default (defaultHumanTimeLocale)
 import           LambdaCms.I18n.Dutch
 import           LambdaCms.I18n.Italian
 import           LambdaCms.I18n.Russian
@@ -16,3 +19,14 @@ lambdaCmsTimeLocale ("it":_) = italianTimeLocale
 lambdaCmsTimeLocale ("ru":_) = russianTimeLocale
 lambdaCmsTimeLocale (_:rest) = lambdaCmsTimeLocale rest
 lambdaCmsTimeLocale []       = defaultTimeLocale
+
+-- | Provide 'HumanTimeLocale' according to given language list.
+lambdaCmsSelectHumanTimeLocale ::  [Text]
+                               -- ^ accept language list
+                               -> (CoreMessage -> String)
+                               -- ^ message render function
+                               -> HumanTimeLocale
+lambdaCmsSelectHumanTimeLocale ("ru":_) = russianHumanTimeLocale
+-- When other language will be added uncomment following line.
+-- lambdaCmsSelectHumanTimeLocale (_:rest) = lambdaCmsSelectHumanTimeLocale rest
+lambdaCmsSelectHumanTimeLocale _        = defaultHumanTimeLocale

--- a/lambdacms-core/LambdaCms/I18n.hs
+++ b/lambdacms-core/LambdaCms/I18n.hs
@@ -11,14 +11,6 @@ import           LambdaCms.I18n.Italian
 import           LambdaCms.I18n.Russian
 
 
--- | Helper function to get the right time locale.
-lambdaCmsTimeLocale :: [Text] -> TimeLocale
-lambdaCmsTimeLocale ("nl":_) = dutchTimeLocale
-lambdaCmsTimeLocale ("it":_) = italianTimeLocale
-lambdaCmsTimeLocale ("ru":_) = russianTimeLocale
-lambdaCmsTimeLocale (_:rest) = lambdaCmsTimeLocale rest
-lambdaCmsTimeLocale []       = defaultTimeLocale
-
 -- | Provide 'HumanTimeLocale' according to given language list.
 lambdaCmsSelectHumanTimeLocale ::  [Text]
                                -- ^ accept language list

--- a/lambdacms-core/LambdaCms/I18n.hs
+++ b/lambdacms-core/LambdaCms/I18n.hs
@@ -14,4 +14,5 @@ lambdaCmsTimeLocale :: [Text] -> TimeLocale
 lambdaCmsTimeLocale ("nl":_) = dutchTimeLocale
 lambdaCmsTimeLocale ("it":_) = italianTimeLocale
 lambdaCmsTimeLocale ("ru":_) = russianTimeLocale
-lambdaCmsTimeLocale _        = defaultTimeLocale
+lambdaCmsTimeLocale (_:rest) = lambdaCmsTimeLocale rest
+lambdaCmsTimeLocale []       = defaultTimeLocale

--- a/lambdacms-core/LambdaCms/I18n.hs
+++ b/lambdacms-core/LambdaCms/I18n.hs
@@ -25,7 +25,8 @@ lambdaCmsSelectHumanTimeLocale ::  [Text]
                                -> (CoreMessage -> String)
                                -- ^ message render function
                                -> HumanTimeLocale
+lambdaCmsSelectHumanTimeLocale ("nl":_) = dutchHumanTimeLocale
+lambdaCmsSelectHumanTimeLocale ("it":_) = italianHumanTimeLocale
 lambdaCmsSelectHumanTimeLocale ("ru":_) = russianHumanTimeLocale
--- When other language will be added uncomment following line.
--- lambdaCmsSelectHumanTimeLocale (_:rest) = lambdaCmsSelectHumanTimeLocale rest
+lambdaCmsSelectHumanTimeLocale (_:rest) = lambdaCmsSelectHumanTimeLocale rest
 lambdaCmsSelectHumanTimeLocale _        = defaultHumanTimeLocale

--- a/lambdacms-core/LambdaCms/I18n/Default.hs
+++ b/lambdacms-core/LambdaCms/I18n/Default.hs
@@ -1,0 +1,28 @@
+module LambdaCms.I18n.Default where
+
+import           Data.Text              (pack)
+import           Data.Time              (utc)
+import           Data.Time.Format       (defaultTimeLocale)
+import           Data.Time.Format.Human (HumanTimeLocale (..))
+import           LambdaCms.Core.Message (CoreMessage (..))
+
+
+defaultHumanTimeLocale :: (CoreMessage -> String) -> HumanTimeLocale
+defaultHumanTimeLocale render = HumanTimeLocale
+    { justNow       = render TimeJustNow
+    , secondsAgo    = \_ x -> render . TimeSecondsAgo $ pack x
+    , oneMinuteAgo  = \_   -> render TimeOneMinuteAgo
+    , minutesAgo    = \_ x -> render . TimeMinutesAgo $ pack x
+    , oneHourAgo    = \_   -> render TimeOneHourAgo
+    , aboutHoursAgo = \_ x -> render . TimeAboutHoursAgo $ pack x
+    , at            = \_ x -> render . TimeAt $ pack x
+    , daysAgo       = \_ x -> render . TimeDaysAgo $ pack x
+    , weekAgo       = \_ x -> render . TimeWeekAgo $ pack x
+    , weeksAgo      = \_ x -> render . TimeWeeksAgo $ pack x
+    , onYear        = render . TimeOnYear . pack
+    , locale        = defaultTimeLocale
+    , dayOfWeekFmt  = render DayOfWeekFmt
+    , thisYearFmt   = "%b %e"
+    , prevYearFmt   = "%b %e, %Y"
+    , timeZone      = utc
+    }

--- a/lambdacms-core/LambdaCms/I18n/Dutch.hs
+++ b/lambdacms-core/LambdaCms/I18n/Dutch.hs
@@ -1,6 +1,9 @@
 module LambdaCms.I18n.Dutch where
 
 import           Data.Time.Format (TimeLocale(..))
+import           Data.Time.Format.Human (HumanTimeLocale (..))
+import           LambdaCms.Core.Message (CoreMessage (..))
+import           LambdaCms.I18n.Default (defaultHumanTimeLocale)
 
 
 -- | Dutch time locale.
@@ -26,3 +29,7 @@ dutchTimeLocale =  TimeLocale
         time12Fmt = "%H:%M:%S",
         knownTimeZones = []
     }
+
+-- | Dutch 'HumanTimeLocale'
+dutchHumanTimeLocale :: (CoreMessage -> String) -> HumanTimeLocale
+dutchHumanTimeLocale r = (defaultHumanTimeLocale r) { locale = dutchTimeLocale }

--- a/lambdacms-core/LambdaCms/I18n/Italian.hs
+++ b/lambdacms-core/LambdaCms/I18n/Italian.hs
@@ -1,6 +1,9 @@
 module LambdaCms.I18n.Italian where
 
 import           Data.Time.Format (TimeLocale(..))
+import           Data.Time.Format.Human (HumanTimeLocale (..))
+import           LambdaCms.Core.Message (CoreMessage (..))
+import           LambdaCms.I18n.Default (defaultHumanTimeLocale)
 
 
 -- | Italian time locale.
@@ -26,3 +29,8 @@ italianTimeLocale =  TimeLocale
         time12Fmt = "%H:%M:%S",
         knownTimeZones = []
     }
+
+-- | Italian 'HumanTimeLocale'
+italianHumanTimeLocale :: (CoreMessage -> String) -> HumanTimeLocale
+italianHumanTimeLocale r = (defaultHumanTimeLocale r)
+    { locale = italianTimeLocale }

--- a/lambdacms-core/LambdaCms/I18n/Russian.hs
+++ b/lambdacms-core/LambdaCms/I18n/Russian.hs
@@ -1,6 +1,6 @@
 module LambdaCms.I18n.Russian where
 
-import           Data.Time.Format (TimeLocale (..))
+import           Data.Time.Format       (TimeLocale (..))
 import           Data.Time.Format.Human (HumanTimeLocale (..))
 import           LambdaCms.Core.Message (CoreMessage (..))
 import           LambdaCms.I18n.Default (defaultHumanTimeLocale)
@@ -9,25 +9,24 @@ import           LambdaCms.I18n.Default (defaultHumanTimeLocale)
 -- | Russian time locale.
 russianTimeLocale :: TimeLocale
 russianTimeLocale =  TimeLocale
-    {
-        wDays  = [("Воскресенье", "Вс"),  ("Понедельник", "Пн"),
-                  ("Вторник",     "Вт"),  ("Среда",       "Ср"),
-                  ("Четверг",     "Чт"),  ("Пятница",     "Пт"),
-                  ("Суббота",     "Сб")],
+    { wDays  = [("Воскресенье", "Вс"),  ("Понедельник", "Пн"),
+                ("Вторник",     "Вт"),  ("Среда",       "Ср"),
+                ("Четверг",     "Чт"),  ("Пятница",     "Пт"),
+                ("Суббота",     "Сб")]
 
-        months = [("Январь",   "Янв"), ("Февраль", "Фев"),
-                  ("Март",     "Мар"), ("Апрель",  "Апр"),
-                  ("Май",      "Май"), ("Июнь",    "Июн"),
-                  ("Июль",     "Июл"), ("Август",  "Авг"),
-                  ("Сентябрь", "Сен"), ("Октябрь", "Окт"),
-                  ("Ноябрь",   "Ноя"), ("Декабрь", "Дек")],
+    , months = [("Январь",   "Янв"), ("Февраль", "Фев"),
+                ("Март",     "Мар"), ("Апрель",  "Апр"),
+                ("Май",      "Май"), ("Июнь",    "Июн"),
+                ("Июль",     "Июл"), ("Август",  "Авг"),
+                ("Сентябрь", "Сен"), ("Октябрь", "Окт"),
+                ("Ноябрь",   "Ноя"), ("Декабрь", "Дек")]
 
-        amPm = ("am", "pm"),
-        dateTimeFmt = "%a, %e %b %Y %H:%M:%S %Z",
-        dateFmt = "%d.%m.%y",
-        timeFmt = "%H:%M:%S",
-        time12Fmt = "%H:%M:%S",
-        knownTimeZones = []
+    , amPm = ("am", "pm")
+    , dateTimeFmt = "%a, %e %b %Y %H:%M:%S %Z"
+    , dateFmt = "%d.%m.%y"
+    , timeFmt = "%H:%M:%S"
+    , time12Fmt = "%H:%M:%S"
+    , knownTimeZones = []
     }
 
 -- | Russian 'HumanTimeLocale'

--- a/lambdacms-core/LambdaCms/I18n/Russian.hs
+++ b/lambdacms-core/LambdaCms/I18n/Russian.hs
@@ -1,6 +1,9 @@
 module LambdaCms.I18n.Russian where
 
 import           Data.Time.Format (TimeLocale (..))
+import           Data.Time.Format.Human (HumanTimeLocale (..))
+import           LambdaCms.Core.Message (CoreMessage (..))
+import           LambdaCms.I18n.Default (defaultHumanTimeLocale)
 
 
 -- | Russian time locale.
@@ -26,3 +29,10 @@ russianTimeLocale =  TimeLocale
         time12Fmt = "%H:%M:%S",
         knownTimeZones = []
     }
+
+-- | Russian 'HumanTimeLocale'
+russianHumanTimeLocale :: (CoreMessage -> String) -> HumanTimeLocale
+russianHumanTimeLocale r = (defaultHumanTimeLocale r)
+    { locale = russianTimeLocale
+    , thisYearFmt = "%e %b"
+    , prevYearFmt = "%e %b %Y"}

--- a/lambdacms-core/lambdacms-core.cabal
+++ b/lambdacms-core/lambdacms-core.cabal
@@ -44,13 +44,13 @@ library
                   , LambdaCms.Core.Settings
                     -- for the test suite
                   , LambdaCms.Core.Foundation
-  other-modules:    LambdaCms.Core.Models
-                  , LambdaCms.Core.Classes
-                  , LambdaCms.Core.Import
+  other-modules:    LambdaCms.Core.Classes
                   , LambdaCms.Core.Handler.ActionLog
                   , LambdaCms.Core.Handler.Home
                   , LambdaCms.Core.Handler.Static
                   , LambdaCms.Core.Handler.User
+                  , LambdaCms.Core.Import
+                  , LambdaCms.Core.Models
                   , LambdaCms.I18n
                   , LambdaCms.I18n.Default
                   , LambdaCms.I18n.Dutch

--- a/lambdacms-core/lambdacms-core.cabal
+++ b/lambdacms-core/lambdacms-core.cabal
@@ -52,6 +52,7 @@ library
                   , LambdaCms.Core.Handler.Static
                   , LambdaCms.Core.Handler.User
                   , LambdaCms.I18n
+                  , LambdaCms.I18n.Default
                   , LambdaCms.I18n.Dutch
                   , LambdaCms.I18n.Italian
                   , LambdaCms.I18n.Russian


### PR DESCRIPTION
This makes possible to override `HumanTimeLocale` fields, which could be necessary for some languages, e.g. Russian (related #18).

@cies don't merge this yet because I have a question.  Now `lambdaCmsTimeLocale` seems to be redundant.  Look, we can remove this function and instead of that define functions returning `HumanTimeLocale`s in each language module, e.g.:

``` hs
-- module LambdaCms.I18n.Dutch
dutchHumanTimeLocale :: (CoreMessage -> String) -> HumanTimeLocale
dutchHumanTimeLocale rm = (defaultHumanTimeLocale rm) { timeLocale = dutchTimeLocale }

-- module LambdaCms.I18n.Italian
italianHumanTimeLocale rm = (defaultHumanTimeLocale rm) { timeLocale = italianTimeLocale }

-- module LambdaCms.I18n
lambdaCmsSelectHumanTimeLocale ("nl":_) = dutchHumanTimeLocale
lambdaCmsSelectHumanTimeLocale ("it":_) = italianHumanTimeLocale
lambdaCmsSelectHumanTimeLocale ("ru":_) = russianHumanTimeLocale
lambdaCmsSelectHumanTimeLocale (_:rest) = lambdaCmsSelectHumanTimeLocale rest
lambdaCmsSelectHumanTimeLocale _        = defaultHumanTimeLocale

-- module LambdaCms.Core.Foundation
lambdaCmsHumanTimeLocale = do
    langs <- languages
    y <- getYesod
    let rm = unpack . renderMessage y langs
        htl = lambdaCmsSelectHumanTimeLocale langs rm
    return htl
```

What will you say?
